### PR TITLE
Use after_create to make sure created_at is set when used in tally

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -19,7 +19,7 @@ class Entry < ActiveRecord::Base
 
   scope :current, -> { where(created_at: Date.today.beginning_of_day..Date.today.end_of_day) }
 
-  before_save :tally
+  after_create :tally
 
   def tally
     cron = CronParser.new(scrum.team.summary_at)


### PR DESCRIPTION
##### Context

I was entering my scrum and there was no echo of the entry
Airbrake let me know that we had an error in [entry.rb:28](https://github.com/astroscrum/rails-api/blob/master/app/models/entry.rb#L28):

``` ruby
# when astroscrum-slackbot posted my entry to https://astroscrum-api.herokuapp.com/v1/entries
error message: NoMethodError: undefined method `<' for nil:NilClass 
location: app/models/entry.rb:28 in tally
```

``` ruby
# line 28
if created_at < ActiveSupport::TimeZone.new(scrum.team.timezone).local_to_utc(entries_due_at)
```
##### Broken :o

![image](https://cloud.githubusercontent.com/assets/940237/7335955/a8dda3ae-eb96-11e4-9af9-4ef33ae49b81.png)
##### After deploying fix/tally-hook branch

![image](https://cloud.githubusercontent.com/assets/940237/7335958/d2a9dfc2-eb96-11e4-8bba-107cee73fc78.png)
